### PR TITLE
Do not create new price entries for cancelled orders that don't ...

### DIFF
--- a/src/main/java/com/coinbase/exchange/api/gui/orderbook/OrderBookModel.java
+++ b/src/main/java/com/coinbase/exchange/api/gui/orderbook/OrderBookModel.java
@@ -247,6 +247,11 @@ public class OrderBookModel implements TableModel, TableModelListener {
                 && item.getReason() != null && item.getReason().equals(CANCELED);
     }
 
+    private boolean isCanceledOrder(OrderBookMessage item) {
+        return item.getType() != null && item.getType().equals(DONE)
+                && item.getReason() != null && item.getReason().equals(CANCELED);
+    }
+
     private void createNewEntry(OrderItem item, Vector vector, int rowIndex) {
         if (!isDoneFilledOrder(item)) {
             data.insertElementAt(vector, rowIndex);
@@ -273,14 +278,14 @@ public class OrderBookModel implements TableModel, TableModelListener {
                 && item.getReason() != null && item.getReason().equals(FILLED);
     }
 
-    public int insertInto(OrderBookMessage msg) {
+    public void insertInto(OrderBookMessage msg) {
 
         List<OrderBookMessage> orderIndex = getListOfAllRelevantOrders(msg);
         Comparator<OrderBookMessage> priceComparator = orderBookMessagePriceComparator();
 
         int index = Collections.binarySearch(orderIndex, msg, priceComparator);
 
-        if (index < 0) {
+        if (index < 0 && !isCanceledOrder(msg)) {
             // item did not exist so negative index for the insertion point was returned
             // insert item at this point
             index = (index * -1) - 1;
@@ -298,8 +303,9 @@ public class OrderBookModel implements TableModel, TableModelListener {
             updateExistingEntry(convertToOrderItem(msg), index);
         }
 
-        validateOrderBookElseRemoveRow(index);
-        return index;
+        if (index >=0) {
+            validateOrderBookElseRemoveRow(index);
+        }
     }
 
     private boolean isDoneFilledOrder(OrderBookMessage message) {

--- a/src/test/resources/testdata/cancelSell_priceDoesNotExist_001.json
+++ b/src/test/resources/testdata/cancelSell_priceDoesNotExist_001.json
@@ -1,0 +1,1 @@
+{"type":"done","side":"sell","order_id":"1481a2c0-5485-41a6-981b-33077a187f14","reason":"canceled","product_id":"BTC-GBP","price":"7940.26000000","remaining_size":"1.87400000","sequence":123457,"time":"2018-02-28T06:18:30.103000Z"}


### PR DESCRIPTION
currently have price entries in the order book. These are IOC trades whose lifecycle does not include open message types for the received orders placed.